### PR TITLE
Remove kiosk locked binary sensor

### DIFF
--- a/custom_components/fullykiosk/binary_sensor.py
+++ b/custom_components/fullykiosk/binary_sensor.py
@@ -9,7 +9,6 @@ _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES = {
     "kioskMode": "Kiosk Mode",
-    "kioskLocked": "Kiosk Locked",
     "plugged": "Plugged In",
     "isDeviceAdmin": "Device Admin",
 }


### PR DESCRIPTION
Remove the kiosk locked binary sensor. It has been converted to a switch in the previous PR.