### PR TITLE
Add unit of measurement for battery sensor

### DIFF
--- a/custom_components/fullykiosk/sensor.py
+++ b/custom_components/fullykiosk/sensor.py
@@ -1,7 +1,7 @@
 """Fully Kiosk Browser sensor."""
 import logging
 
-from homeassistant.const import DEVICE_CLASS_BATTERY
+from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, COORDINATOR
@@ -56,7 +56,7 @@ class FullySensor(Entity):
     @property
     def unit_of_measurement(self):
         if self._sensor == "batteryLevel":
-            return "%"
+            return PERCENTAGE
         return None
 
     @property

--- a/custom_components/fullykiosk/sensor.py
+++ b/custom_components/fullykiosk/sensor.py
@@ -54,6 +54,12 @@ class FullySensor(Entity):
         return None
 
     @property
+    def unit_of_measurement(self):
+        if self._sensor == "batteryLevel":
+            return "%"
+        return None
+
+    @property
     def device_info(self):
         return {
             "identifiers": {(DOMAIN, self.coordinator.data["deviceID"])},


### PR DESCRIPTION
In order for the battery sensor to be detected as numeric, it needs to have a unit of measurement.