### PR TITLE
Fix KeyError in switch.py and light.py

### DIFF
--- a/custom_components/fullykiosk/light.py
+++ b/custom_components/fullykiosk/light.py
@@ -35,6 +35,8 @@ class FullyLight(LightEntity):
 
     @property
     def is_on(self):
+        if self.coordinator.data["appVersionCode"] < 784:
+            return self.coordinator.data["isScreenOn"]
         return self.coordinator.data["screenOn"]
 
     @property

--- a/custom_components/fullykiosk/light.py
+++ b/custom_components/fullykiosk/light.py
@@ -35,7 +35,7 @@ class FullyLight(LightEntity):
 
     @property
     def is_on(self):
-        return self.coordinator.data["isScreenOn"]
+        return self.coordinator.data["screenOn"]
 
     @property
     def brightness(self):

--- a/custom_components/fullykiosk/switch.py
+++ b/custom_components/fullykiosk/switch.py
@@ -70,7 +70,7 @@ class FullyScreenSaverSwitch(FullySwitch):
 
     @property
     def is_on(self):
-        return self.coordinator.data["currentFragment"] == "screensaver"
+        return self.coordinator.data["isInScreensaver"]
 
     async def async_turn_on(self, **kwargs):
         await self.hass.async_add_executor_job(self.controller.startScreensaver)

--- a/custom_components/fullykiosk/switch.py
+++ b/custom_components/fullykiosk/switch.py
@@ -70,6 +70,8 @@ class FullyScreenSaverSwitch(FullySwitch):
 
     @property
     def is_on(self):
+        if self.coordinator.data["appVersionCode"] < 784:
+            return self.coordinator.data["currentFragment"] == "screensaver"
         return self.coordinator.data["isInScreensaver"]
 
     async def async_turn_on(self, **kwargs):


### PR DESCRIPTION
Screensaver key should be 'isInScreensaver'
Screen on key should be 'screenOn'

The following errors are observed with Fully Kiosk App v1.40.3 and v1.42.2, possibly due to an API update in the app:

```
2020-10-11 15:24:59 ERROR (MainThread) [homeassistant.components.switch] Error while setting up fullykiosk platform for switch
Traceback (most recent call last):
  ...
  File "/workspaces/core/homeassistant/helpers/entity.py", line 676, in state
    return STATE_ON if self.is_on else STATE_OFF
  File "/workspaces/core/config/custom_components/fullykiosk/switch.py", line 73, in is_on
    return self.coordinator.data["currentFragment"] == "screensaver"
KeyError: 'currentFragment'

020-10-11 15:24:59 ERROR (MainThread) [homeassistant.components.light] Error while setting up fullykiosk platform for light
Traceback (most recent call last):
  ...
  File "/workspaces/core/homeassistant/helpers/entity.py", line 676, in state
    return STATE_ON if self.is_on else STATE_OFF
  File "/workspaces/core/config/custom_components/fullykiosk/light.py", line 38, in is_on
    return self.coordinator.data["isScreenOn"]
KeyError: 'isScreenOn'
```
