### PR TITLE
Add switch for motion detection

### DIFF
--- a/custom_components/fullykiosk/coordinator.py
+++ b/custom_components/fullykiosk/coordinator.py
@@ -1,6 +1,6 @@
 """Provides the The Fully Kiosk Browser DataUpdateCoordinator."""
-import logging
 import asyncio
+import logging
 from datetime import timedelta
 
 from aiohttp import ClientSession

--- a/custom_components/fullykiosk/coordinator.py
+++ b/custom_components/fullykiosk/coordinator.py
@@ -37,7 +37,9 @@ class FullyKioskDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             with timeout(15):
                 """Get device info and settings in parallel"""
-                result = await asyncio.gather(self.fully.getDeviceInfo(), self.fully.getSettings())
+                result = await asyncio.gather(
+                    self.fully.getDeviceInfo(), self.fully.getSettings()
+                )
                 """Store settings under settings key in data"""
                 result[0]["settings"] = result[1]
                 return result[0]

--- a/custom_components/fullykiosk/coordinator.py
+++ b/custom_components/fullykiosk/coordinator.py
@@ -1,5 +1,6 @@
 """Provides the The Fully Kiosk Browser DataUpdateCoordinator."""
 import logging
+import asyncio
 from datetime import timedelta
 
 from aiohttp import ClientSession
@@ -35,6 +36,10 @@ class FullyKioskDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         try:
             with timeout(15):
-                return await self.fully.getDeviceInfo()
+                """Get device info and settings in parallel"""
+                result = await asyncio.gather(self.fully.getDeviceInfo(), self.fully.getSettings())
+                """Store settings under settings key in data"""
+                result[0]["settings"] = result[1]
+                return result[0]
         except (FullyKioskError, ClientConnectorError) as error:
             raise UpdateFailed(error) from error

--- a/custom_components/fullykiosk/manifest.json
+++ b/custom_components/fullykiosk/manifest.json
@@ -5,7 +5,7 @@
 	"documentation": "https://github.com/cgarwood/homeassistant-fullykiosk",
 	"issue_tracker": "https://github.com/cgarwood/homeassistant-fullykiosk/issues",
 	"requirements": [
-		"python-fullykiosk==0.0.8"
+		"python-fullykiosk==0.0.10"
 	],
 	"ssdp": [],
 	"zeroconf": [],

--- a/custom_components/fullykiosk/switch.py
+++ b/custom_components/fullykiosk/switch.py
@@ -16,6 +16,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities([FullyScreenSaverSwitch(hass, coordinator)], False)
     async_add_entities([FullyMaintenanceModeSwitch(hass, coordinator)], False)
     async_add_entities([FullyKioskLockSwitch(hass, coordinator)], False)
+    async_add_entities([FullyKioskMotionDetectionSwitch(hass, coordinator)], False)
 
 
 class FullySwitch(CoordinatorEntity, SwitchEntity):
@@ -136,4 +137,28 @@ class FullyKioskLockSwitch(FullySwitch):
     async def async_turn_off(self, **kwargs):
         """Turn off kiosk lock."""
         await self.coordinator.fully.unlockKiosk()
+        await self.coordinator.async_refresh()
+
+class FullyKioskMotionDetectionSwitch(FullySwitch):
+    """Representation of a Fully Kiosk Browser kiosk lock switch."""
+
+    def __init__(self, hass, coordinator):
+        """Intialize the kiosk lock switch."""
+        super().__init__(hass, coordinator)
+        self._name = f"{coordinator.data['deviceName']} Motion Detection"
+        self._unique_id = f"{coordinator.data['deviceID']}-motion-detection"
+
+    @property
+    def is_on(self):
+        """Return if motion detection is on."""
+        return self.coordinator.data["settings"]["motionDetection"]
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on kiosk lock."""
+        await self.coordinator.fully.enableMotionDetection()
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off kiosk lock."""
+        await self.coordinator.fully.disableMotionDetection()
         await self.coordinator.async_refresh()

--- a/custom_components/fullykiosk/switch.py
+++ b/custom_components/fullykiosk/switch.py
@@ -140,6 +140,7 @@ class FullyKioskLockSwitch(FullySwitch):
         await self.coordinator.fully.unlockKiosk()
         await self.coordinator.async_refresh()
 
+
 class FullyKioskMotionDetectionSwitch(FullySwitch):
     """Representation of a Fully Kiosk Browser kiosk lock switch."""
 


### PR DESCRIPTION
This depends on my PR here: https://github.com/cgarwood/python-fullykiosk/pull/10

I've tested it to be working on my installation without modifying the underlying python library (harder to reach from vs-code plugin). To do that I just adapted the code from this PR to call existing function in `python-fullykiosk` directly.

So instead of calling `enableMotionDetection` etc I did this:
```python
class FullyKioskMotionDetectionSwitch(FullySwitch):
    """Representation of a Fully Kiosk Browser kiosk lock switch."""

    def __init__(self, hass, coordinator):
        """Intialize the kiosk lock switch."""
        super().__init__(hass, coordinator)
        self._name = f"{coordinator.data['deviceName']} Motion Detection"
        self._unique_id = f"{coordinator.data['deviceID']}-motion-detection"

    @property
    def is_on(self):
        """Return if motion detection is on."""
        return self.coordinator.data["settings"]["motionDetection"]

    async def async_turn_on(self, **kwargs):
        """Turn on kiosk lock."""
        await self.coordinator.fully.setConfigurationBool("motionDetection", True)
        await self.coordinator.async_refresh()

    async def async_turn_off(self, **kwargs):
        """Turn off kiosk lock."""
        await self.coordinator.fully.setConfigurationBool("motionDetection", False)
        await self.coordinator.async_refresh()

```

And instead of calling `getSettings` in `coordinator.py` I did this:
```python
async def _async_update_data(self):
        """Update data via library."""
        try:
            with timeout(15):
                """Get device info and settings in parallel"""
                result = await asyncio.gather(self.fully.getDeviceInfo(), self.fully.sendCommand("listSettings"))
                """Store settings under settings key in data"""
                result[0]["settings"] = result[1]
                return result[0]
        except (FullyKioskError, ClientConnectorError) as error:
            raise UpdateFailed(error) from error
```

Again I don't speak python so check thoroughly!

This should also provide a simple framework for adding other switches for settings.
