### PR TITLE
Bump python-fullykiosk to 0.0.10 to fix Content-Type error with Fully 1.44+

### DIFF
--- a/custom_components/fullykiosk/manifest.json
+++ b/custom_components/fullykiosk/manifest.json
@@ -5,7 +5,7 @@
 	"documentation": "https://github.com/cgarwood/homeassistant-fullykiosk",
 	"issue_tracker": "https://github.com/cgarwood/homeassistant-fullykiosk/issues",
 	"requirements": [
-		"python-fullykiosk==0.0.8"
+		"python-fullykiosk==0.0.10"
 	],
 	"ssdp": [],
 	"zeroconf": [],


### PR DESCRIPTION
Bumps the python library to resolve a JSON decoding error caused by a Content-Type change in Fully Kiosk Browser 1.44.

Fixes #54 