### PR TITLE
Deprecate services replaced by button entities

### DIFF
--- a/custom_components/fullykiosk/media_player.py
+++ b/custom_components/fullykiosk/media_player.py
@@ -151,6 +151,9 @@ class FullyMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     async def async_fullykiosk_load_start_url(self):
         """Load the start URL on a fullykiosk browser."""
+        _LOGGER.warning(
+            "The fullykiosk.load_start_url service is deprecated and will be removed in a future update. Use the corresponding button entity instead."
+        )
         await self.coordinator.fully.loadStartUrl()
         await self.coordinator.async_refresh()
 
@@ -165,13 +168,17 @@ class FullyMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     async def async_fullykiosk_reboot_device(self):
         """Reboot the device running the fullykiosk browser app."""
+        _LOGGER.warning(
+            "The fullykiosk.reboot_device service is deprecated and will be removed in a future update. Use the corresponding button entity instead."
+        )
         await self.coordinator.fully.rebootDevice()
-        await self.coordinator.async_refresh()
 
     async def async_fullykiosk_restart(self):
         """Restart the fullykiosk browser app."""
+        _LOGGER.warning(
+            "The fullykiosk.restart service is deprecated and will be removed in a future update. Use the corresponding button entity instead."
+        )
         await self.coordinator.fully.restartApp()
-        await self.coordinator.async_refresh()
 
     async def async_fullykiosk_set_config(self, config_type, key, value):
         """Set fullykiosk configuration value."""
@@ -191,11 +198,17 @@ class FullyMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     async def async_fullykiosk_to_background(self):
         """Bring the fullykiosk browser app back to the background."""
+        _LOGGER.warning(
+            "The fullykiosk.to_background service is deprecated and will be removed in a future update. Use the corresponding button entity instead."
+        )
         await self.coordinator.fully.toBackground()
         await self.coordinator.async_refresh()
 
     async def async_fullykiosk_to_foreground(self):
         """Bring the fullykiosk browser app back to the foreground."""
+        _LOGGER.warning(
+            "The fullykiosk.to_foreground service is deprecated and will be removed in a future update. Use the corresponding button entity instead."
+        )
         await self.coordinator.fully.toForeground()
         await self.coordinator.async_refresh()
 

--- a/custom_components/fullykiosk/services.yaml
+++ b/custom_components/fullykiosk/services.yaml
@@ -1,8 +1,8 @@
 # Describes the format for available fullykiosk services
 
 load_start_url:
-  name: Load Start URL
-  description: Load Fully Kiosk Browser start URL.
+  name: Load Start URL (deprecated)
+  description: Load Fully Kiosk Browser start URL. ***This service is deprecated and will be removed in a later update. Use the corresponding button entity instead***
   fields:
     entity_id:
       description: Name(s) of entities to load the start URL on.
@@ -66,8 +66,8 @@ play_audio:
           mode: box
 
 reboot_device:
-  name: Reboot Device
-  description: Reboot the device running the Fully Kiosk Browser app.
+  name: Reboot Device (deprecated)
+  description: Reboot the device running the Fully Kiosk Browser app. ***This service is deprecated and will be removed in a later update. Use the corresponding button entity instead***
   fields:
     entity_id:
       description: Name(s) of entities to reboot.
@@ -80,8 +80,8 @@ reboot_device:
           domain: media_player
 
 restart:
-  name: Restart
-  description: Restart the Fully Kiosk Browser app.
+  name: Restart (deprecated)
+  description: Restart the Fully Kiosk Browser app. ***This service is deprecated and will be removed in a later update. Use the corresponding button entity instead***
   fields:
     entity_id:
       description: Name(s) of entities to restart the app on.
@@ -146,8 +146,8 @@ start_application:
         text:
 
 to_foreground:
-  name: To Foreground
-  description: Bring the Fully Kiosk Browser app to the foreground.
+  name: To Foreground (deprecated)
+  description: Bring the Fully Kiosk Browser app to the foreground. ***This service is deprecated and will be removed in a later update. Use the corresponding button entity instead***
   fields:
     entity_id:
       description: Name(s) of entities on which to bring the app to the foreground.
@@ -160,8 +160,8 @@ to_foreground:
           domain: media_player
 
 to_background:
-  name: To Background
-  description: Bring the Fully Kiosk Browser app to the background.
+  name: To Background (deprecated)
+  description: Bring the Fully Kiosk Browser app to the background. ***This service is deprecated and will be removed in a later update. Use the corresponding button entity instead***
   fields:
     entity_id:
       description: Name(s) of entities on which to bring the app to the background.


### PR DESCRIPTION
The fullykiosk.restart, reboot_device, to_foreground, to_background, and load_start_url services are now marked as deprecated. Use the corresponding button entities instead.