### PR TITLE
Tweak sensor state to handle missing attributes

### DIFF
--- a/custom_components/fullykiosk/sensor.py
+++ b/custom_components/fullykiosk/sensor.py
@@ -110,7 +110,7 @@ class FullySensor(CoordinatorEntity, SensorEntity):
         if self._sensor in STORAGE_SENSORS:
             return round(self.coordinator.data[self._sensor] * 0.000001, 1)
 
-        return self.coordinator.data[self._sensor]
+        return self.coordinator.data.get(self._sensor)
 
     async def async_added_to_hass(self):
         """Connect to dispatcher listening for entity data notifications."""


### PR DESCRIPTION
Should fix #67 by returning `None` as the state if the attribute is missing.