### PR TITLE
Set minimum HA version for HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
 	"name": "Fully Kiosk Browser",
-	"render_readme": true
+	"render_readme": true,
+	"homeassistant": "2022.7.0b0"
 }


### PR DESCRIPTION
Minimum HA version is now 2022.7.0b0
Required due to #108 